### PR TITLE
统一战宠和类召唤物召唤技能伤害加成的描述

### DIFF
--- a/translation/aom/tagsgdx1_skills.txt
+++ b/translation/aom/tagsgdx1_skills.txt
@@ -77,7 +77,7 @@ tagGDX1Class07SkillName04E=[审判官]污染之焰
 tagGDX1Class07SkillDescription04E=罕见的是，一些审判官已经堕落并信奉他们曾经对抗的力量。将虚无之力注入伊格纳法之石，使其释放出一道污染之焰。
 
 tagGDX1Class07SkillName05A=[审判官]哈加拉德符文
-tagGDX1Class07SkillDescription05A=哈格拉符文最初只是收藏于光明会宝库的藏品之一，但在消灭了给帝国首都带来巨大压力的神秘活动之后，它成为了第一个被批准研究的圣物，并被光明会复制用以切断敌人的逃生路线。^o哈加拉德符文需要1.5秒部署时间并受到玩家伤害加成的影响。冰锥最初的伤害会降低25%，向外扩散之后会造成全额伤害。
+tagGDX1Class07SkillDescription05A=哈格拉符文最初只是收藏于光明会宝库的藏品之一，但在消灭了给帝国首都带来巨大压力的神秘活动之后，它成为了第一个被批准研究的圣物，并被光明会复制用以切断敌人的逃生路线。^o哈加拉德符文需要1.5秒部署时间并会受到玩家伤害加成的影响。冰锥最初的伤害会降低25%，向外扩散之后会造成全额伤害。
 tagGDX1Class07SkillName05A_PetSkill=寒冷冲击
 tagGDX1Class07SkillName05B=[审判官]凛冽
 tagGDX1Class07SkillDescription05B=哈加拉德符文散发的寒冷能量能使敌人思维迟缓更利于猎杀。
@@ -141,7 +141,7 @@ xxtagGDX1Class08SkillName01D=[死灵法师]无尽渴望
 xxtagGDX1Class08SkillDescription01D=生命精华的转移通常是一种只为极端情况而保留的做法，但有些信徒难以抵御鲜活生命力的诱惑，并屈服于自己的力量，以牺牲周围的人为代价来满足自己。
 
 tagGDX1Class08SkillName02A=[死灵法师]骷髅复生
-tagGDX1Class08SkillDescription02A=使骷髅残骸复生的艺术是死灵法师追求的首要仪式，但也是最基础的。凭借纯粹的意志，死灵法师能召唤冥界的灵魂并注入死者的骸骨。如果仪式成功，会使只忠于召唤者的骷髅仆从复生。^o骷髅受到宠物伤害加成的影响。仆从的战力随着技能等级而提升。
+tagGDX1Class08SkillDescription02A=使骷髅残骸复生的艺术是死灵法师追求的首要仪式，但也是最基础的。凭借纯粹的意志，死灵法师能召唤冥界的灵魂并注入死者的骸骨。如果仪式成功，会使只忠于召唤者的骷髅仆从复生。^o骷髅会受到战宠加成的影响。仆从的战力随着技能等级而提升。
 tagGDX1Class08SkillTracker02A=当前召唤骷髅数量
 tagGDX1Class08SkillName02A_PetSkill=古代兵器
 tagGDX1Class08SkillName02A_PetSkill02=火焰碎片
@@ -176,7 +176,7 @@ tagGDX1Class08SkillName04C=[死灵法师]腐臭喷发
 tagGDX1Class08SkillDescription04C=邪恶的死灵能量充满肉体，使被杀的敌人会猛烈的喷发，把疾病和脓水泼向附近的敌人。
 
 tagGDX1Class08SkillName05A=[死灵法师]召唤疫病恶魔
-tagGDX1Class08SkillDescription05A=面对腐烂的有毒烟雾不为所动，从大地中召唤出由尸体和腐烂的污秽组成的憎恶并压制你的敌人。^o同一时间只能召唤一只疫病恶魔。疫病恶魔受到宠物伤害加成的影响。
+tagGDX1Class08SkillDescription05A=面对腐烂的有毒烟雾不为所动，从大地中召唤出由尸体和腐烂的污秽组成的憎恶并压制你的敌人。^o同一时间只能召唤一只疫病恶魔。疫病恶魔会受到战宠加成的影响。
 tagGDX1Class08SkillName05A_PetSkill=毁灭之爪
 tagGDX1Class08SkillName05A_PetSkill02=致命死亡
 tagGDX1Class08SkillName05B=[死灵法师]腐烂气息
@@ -202,7 +202,7 @@ tagGDX1Class08SkillName08A=[死灵法师]恶兆
 tagGDX1Class08SkillDescription08A=死灵法师的存在足矣惊恐敌人，鬼魂的哀嚎将粉碎敌人的信心并使混乱和恐惧在敌人中迅速蔓延。
 
 tagGDX1Class08SkillName09A=[死灵法师]精魂收割
-tagGDX1Class08SkillDescription09A=尤若布鲁克赋予信徒的强大技术之一。通过撕裂你的敌人，不仅可以造成严重的伤害，而且可以召唤出他们灵魂的一部分来为你服务。由此产生的精魂是不稳定的且有高度的侵略性，这使得它在战斗中非常有用。^o幽灵受到宠物伤害加成的影响。
+tagGDX1Class08SkillDescription09A=尤若布鲁克赋予信徒的强大技术之一。通过撕裂你的敌人，不仅可以造成严重的伤害，而且可以召唤出他们灵魂的一部分来为你服务。由此产生的精魂是不稳定的且有高度的侵略性，这使得它在战斗中非常有用。^o幽灵会受到战宠加成的影响。
 tagGDX1Class08SkillName09A_PetSkill=幽灵之触
 tagGDX1Class08SkillName09A_PetSkill02=活力新星
 tagGDX1Class08SkillTracker09A=当前召唤的幽魂数量
@@ -408,7 +408,7 @@ tagGDX1ItemSkillD144Name=符文守卫
 tagGDX1ItemSkillD144Desc=符文被刻在护甲上，保护你免受奥术伤害。
 
 tagGDX1ItemSkillD145Name=余烬之风
-tagGDX1ItemSkillD145Desc=召唤火焰生命体焚烧你的敌人。 ^o余烬之风受到玩家伤害加成的影响。
+tagGDX1ItemSkillD145Desc=召唤火焰生命体焚烧你的敌人。 ^o余烬之风会受到玩家伤害加成的影响。
 
 tagGDX1ItemSkillD146Name=掠夺者的死亡凝视
 tagGDX1ItemSkillD146Desc=掠夺者的凝视落在附近敌人身上，削弱他们的防御能力。
@@ -513,11 +513,11 @@ tagGDX1ItemSkillD179Name=饮魔者
 tagGDX1ItemSkillD179Desc=加强你的武器与奥术之间的共鸣，吸收部分敌人的法术并将其中一部分灌注于你的法术之中。^o此技能必须开启才能持续生效。
 
 tagGDX1ItemSkillD180Name=召唤血浴奴仆
-tagGDX1ItemSkillD180Desc=在坟墓的折磨降临在血浴奴仆们的身上之前，召唤出他们向敌人施放活力吸取法术。^o血浴奴仆受到玩家伤害加成影响。
+tagGDX1ItemSkillD180Desc=在坟墓的折磨降临在血浴奴仆们的身上之前，召唤出他们向敌人施放活力吸取法术。^o血浴奴仆会受到玩家伤害加成的影响。
 tagGDX1ItemSkillD180SkillTracker=已召唤血浴奴仆数
 
 tagGDX1ItemSkillD181Name=纳扎染之魂
-tagGDX1ItemSkillD181Desc=召唤纳扎染受折磨的灵魂来猛击敌人，将敌人遭受的痛苦转化为生命力传导给你。^o同一时间只能召唤一个纳扎染的灵魂。领主纳扎染的伤害受到玩家的伤害加成。
+tagGDX1ItemSkillD181Desc=召唤纳扎染受折磨的灵魂来猛击敌人，将敌人遭受的痛苦转化为生命力传导给你。^o同一时间只能召唤一个纳扎染的灵魂。领主纳扎染会受到玩家伤害加成的影响。
 
 tagGDX1ItemSkillD182Name=寒舌标记
 tagGDX1ItemSkillD182Desc=寒舌的标记以在政治精英中间散播冲突和混乱而闻名。将它对敌人施放时，敌人会充满不安，感到受困。
@@ -586,7 +586,7 @@ tagGDX1RelicSkillB104Name=盾牌猛击
 tagGDX1RelicSkillB104Desc=用盾牌猛击你的敌人，使他们进入懵逼状态。^o需要一个近战武器和盾牌。
 
 tagGDX1RelicSkillB105Name=召唤灵魂蟹
-tagGDX1RelicSkillB105Desc=束缚一个沼泽生物的灵魂为你服务。灵魂的冰冷攻击使敌人不寒而栗。^o同一时间只能召唤一只灵魂蟹。灵魂蟹受到宠物伤害加成的影响。
+tagGDX1RelicSkillB105Desc=束缚一个沼泽生物的灵魂为你服务。灵魂的冰冷攻击使敌人不寒而栗。^o同一时间只能召唤一只灵魂蟹。灵魂蟹会受到战宠加成的影响。
 tagGDX1RelicSkillB105Name_PetSkill=蟹爪
 
 tagGDX1RelicSkillC101Name=死亡命运
@@ -602,7 +602,7 @@ tagGDX1RelicSkillD102Name=寒冷复仇
 tagGDX1RelicSkillD102Desc=对胆敢攻击你的敌人释放一股寒冷力量的冲击。
 
 tagGDX1RelicSkillD103Name=召唤骸骨仆从
-tagGDX1RelicSkillD103Desc=结合了上百个受折磨灵魂的骸骨将为你效劳，这只可怕的生物劈砍着敌人并用骸骨牢笼困住他们。^o同一时间只能召唤一只骸骨仆从。骸骨仆从受到宠物伤害加成的影响。
+tagGDX1RelicSkillD103Desc=结合了上百个受折磨灵魂的骸骨将为你效劳，这只可怕的生物劈砍着敌人并用骸骨牢笼困住他们。^o同一时间只能召唤一只骸骨仆从。骸骨仆从会受到战宠加成的影响。
 tagGDX1RelicSkillD103Name_PetSkill=骸骨之爪
 
 tagGDX1RelicSkillD104Name=元素诅咒
@@ -637,7 +637,7 @@ tagGDX1RelicSkillD113Desc=野兽之神的祝福围绕着你和你的仆从，保
 
 
 tagGDX1RelicSkillD114Name=召唤死亡追猎者
-tagGDX1RelicSkillD114Desc=召唤出死亡追猎者，它便是象征着莫格卓根怒火的可怕化身。它能够粉碎附近敌人对物理，毒素和流血效果的抗性。^o同一时间只能召唤一头死亡追猎者。死亡追猎者受到玩家的伤害加成影响。
+tagGDX1RelicSkillD114Desc=召唤出死亡追猎者，它便是象征着莫格卓根怒火的可怕化身。它能够粉碎附近敌人对物理，毒素和流血效果的抗性。^o同一时间只能召唤一头死亡追猎者。死亡追猎者会受到玩家伤害加成的影响。
 tagGDX1RelicSkillD114_Skill=黑暗光环
 tagGDX1RelicSkillD114_Desc=一头来自黑暗的生物追捕着你的敌人，粉碎他们的物理，毒素和流血抗性。
 
@@ -739,7 +739,7 @@ tagGDX1DevotionEffectC102Desc=春天的抚慰之风将你包裹在一个保护�
 tagGDX1DevotionEffectC103=维尔之拳
 tagGDX1DevotionEffectC103Desc=维尔的碎裂之拳拔地而起，以大地之力征服敌人。
 tagGDX1DevotionEffectC104=奥术电流
-tagGDX1DevotionEffectC104Desc=在地上刻下怪异的符号，迅速对附近敌人释放奥术能量电流。^o奥术电流受到玩家伤害加成的影响。
+tagGDX1DevotionEffectC104Desc=在地上刻下怪异的符号，迅速对附近敌人释放奥术能量电流。^o奥术电流会受到玩家伤害加成的影响。
 tagGDX1DevotionEffectC104PetSkill=汹涌
 tagGDX1DevotionEffectC105=莱托什的意志
 tagGDX1DevotionEffectC105Desc=用莱托什的符号标记敌人的灵魂。他们的生命和命运已被封印，任由莱托什的仆从堤丰摆布。

--- a/translation/aom/tagsgdx1_skills.txt
+++ b/translation/aom/tagsgdx1_skills.txt
@@ -429,10 +429,10 @@ tagGDX1ItemSkillD151Name=剧毒术士光环
 tagGDX1ItemSkillD151Desc=用恐怖毒液强化你和附近盟友的武器。 ^o这项技能必须保持开启以持续生效。
 
 tagGDX1ItemSkillD152Name=死灵领主光环
-tagGDX1ItemSkillD152Desc=用不死力量强化你和附近盟友的武器。 ^o这项技能必须保持开启以持续生效。
+tagGDX1ItemSkillD152Desc=用不死力量充满你和附近盟友的武器。 ^o这项技能必须保持开启以持续生效。
 
 tagGDX1ItemSkillD153Name=伊格纳法降临
-tagGDX1ItemSkillD153Desc=用伊格纳法火焰强化你和附近盟友的武器。 ^o这项技能必须保持开启以持续生效。
+tagGDX1ItemSkillD153Desc=用伊格纳法的火焰充满你的护甲，灼烧附近的敌人。 ^o这项技能必须保持开启以持续生效。
 
 tagGDX1ItemSkillD154Name=吉尔多守卫
 tagGDX1ItemSkillD154Desc=预判举起你的盾牌，反击任何近战攻击。

--- a/translation/fg/tagsgdx2_skills.txt
+++ b/translation/fg/tagsgdx2_skills.txt
@@ -71,7 +71,7 @@ tagGDX2Class09SkillDescription07B=正义之火在守誓者的灵魂中燃烧，�
 
 tagGDX2Class09SkillName08A=[守誓者]召唤至高神守护者
 tagGDX1Class09SkillTracker08A=已召唤守护者数量
-tagGDX2Class09SkillDescription08A=召唤至高之神的忠诚仆从，执行天神审判，劈斩敌人。^o天界守护者受到玩家伤害加成的影响。
+tagGDX2Class09SkillDescription08A=召唤至高之神的忠诚仆从，执行天神审判，劈斩敌人。^o天界守护者会受到玩家伤害加成的影响。
 tagGDX2Class09SkillName08B=[守誓者]天神化身
 tagGDX2Class09SkillDescription08B=守护者的出现会灼烧异教徒们的灵魂。
 tagGDX2Class09SkillName08C=[守誓者]德里格之嗣
@@ -206,7 +206,7 @@ tagGDX2ItemSkillD228Name=枯萎感染
 tagGDX2ItemSkillD228Desc=一种可以在你的敌人之间传播使他们虚弱、意志消沉的传染病。
 
 tagGDX2ItemSkillD229Name=召唤恐惧织网者
-tagGDX2ItemSkillD229Desc=在扭曲环境中凭借可怕的能量从邪术领域中召唤织网者。这个召唤物的存在是不稳定，因此它们只会存在很短的时间就返回它们的巢穴。^o织网者受到宠物伤害加成影响。
+tagGDX2ItemSkillD229Desc=在扭曲环境中凭借可怕的能量从邪术领域中召唤织网者。这个召唤物的存在是不稳定，因此它们只会存在很短的时间就返回它们的巢穴。^o织网者会受到战宠加成的影响。
 tagGDX2ItemSkillD229_Pet01=蜘蛛獠牙
 
 tagGDX2ItemSkillD230Name=邪术碎片
@@ -223,7 +223,7 @@ tagGDX2ItemSkillD232Name=枯萎领主的馈赠
 tagGDX2ItemSkillD232Desc=枯萎领主的馈赠会标记你的敌人，给予你的敌人虚弱诅咒从而更容易传播与感染。
 
 tagGDX2ItemSkillD233Name=召唤邪能利爪
-tagGDX2ItemSkillD233Desc=召唤一个恶魔与你并肩作战。邪能利爪将会撕裂附近敌人的存在。^o同一时间只能召唤一只邪能利爪。邪能利爪会受到战宠加成影响。
+tagGDX2ItemSkillD233Desc=召唤一个恶魔与你并肩作战。邪能利爪将会撕裂附近敌人的存在。^o同一时间只能召唤一只邪能利爪。邪能利爪会受到战宠加成的影响。
 tagGDX2ItemSkillD233_Pet01=邪能之爪
 tagGDX2ItemSkillD233_Pet02=邪能动荡
 tagGDX2ItemSkillD233_Pet02Desc=邪能利爪将会撕裂附近的敌人，削弱他们的抗性和攻击。
@@ -287,7 +287,7 @@ tagGDX2ItemSkillD255Name=孔萨尔的凝视
 tagGDX2ItemSkillD255Desc=孔萨尔的凝视落在你的仆从身上，使他们充满愤恨。
 
 tagGDX2ItemSkillD256Name=尤戈尔的祈祷
-tagGDX2ItemSkillD256Desc=祈求诅咒星辰的仪式，召唤出巨大的天界饥渴的表象。^o表象受玩家加成影响。
+tagGDX2ItemSkillD256Desc=祈求诅咒星辰的仪式，召唤出巨大的天界饥渴的表象。^o表象会受到玩家伤害加成的影响。
 tagGDX2ItemSkillD256PetSkill_Name=挥打
 tagGDX2ItemSkillD256PetSkill2_Name=黑暗降临
 
@@ -307,7 +307,7 @@ tagGDX2ItemSkillD261Name=海瑞恩之爪
 tagGDX2ItemSkillD261Desc=用你盾牌里已注入的海瑞恩之力猛击你的敌人。
 
 tagGDX2ItemSkillD262Name=世界之门
-tagGDX2ItemSkillD262Desc=在现实中撕开一道裂隙，将站在其中的敌人分割开来。^o世界之门受战宠加成影响。
+tagGDX2ItemSkillD262Desc=在现实中撕开一道裂隙，将站在其中的敌人分割开来。^o世界之门会受到战宠加成的影响。
 tagGDX2ItemSkillD262PetSkill_Name=分割
 
 
@@ -330,7 +330,7 @@ tagGDX2RelicSkillD202Name=维尔爆发
 tagGDX2RelicSkillD202Desc=猛击地面，并且使你面前的地面呈现扇形的破碎区域。
 
 tagGDX2RelicSkillD203Name=沙暴
-tagGDX2RelicSkillD203Desc=像你的敌人释放沙暴。^o沙暴受到人物伤害的加成。
+tagGDX2RelicSkillD203Desc=像你的敌人释放沙暴。^o沙暴会受到玩家伤害加成的影响。
 
 tagGDX2RelicSkillD204Name=饥渴之触
 tagGDX2RelicSkillD204Desc=把你的愤怒集中在代表你饥渴的旋风中，只要你持续施法就会消耗你周围人的鲜血。 ^o需要一把近战武器。攻速为100%时，饥渴之触每0.16秒造成伤害并消耗能量。

--- a/translation/tags_items.txt
+++ b/translation/tags_items.txt
@@ -2142,7 +2142,7 @@ tagBlueprint_MaterialA01=^f设计图：虚化集簇
 
 #Relics 圣物
 
-tagDeviceBonus=完整部件奖励
+tagDeviceBonus=完成奖励
 tagDeviceTier01=注魔圣物
 tagDeviceTier02=卓越圣物
 tagDeviceTier03=神话圣物

--- a/translation/tags_skills.txt
+++ b/translation/tags_skills.txt
@@ -273,7 +273,7 @@ tagClass03SkillName00=神秘学者
 tagClass03SkillDescription00=深入研习如何操纵与控制神秘力量。
 
 tagClass03SkillName01A=[神秘学者]召唤乌鸦
-tagClass03SkillDescription01A=召唤神话中的风暴乌鸦来援助你。风暴乌鸦是与寻常乌鸦不同的一种拥有不可思议的智慧和魔力的奇异生物。有些人坚信它们不是鸟，而是以乌鸦的形式现身的某种古老的天空之灵。^o同一时间只能召唤一只乌鸦。乌鸦会受到战宠加成影响。
+tagClass03SkillDescription01A=召唤神话中的风暴乌鸦来援助你。风暴乌鸦是与寻常乌鸦不同的一种拥有不可思议的智慧和魔力的奇异生物。有些人坚信它们不是鸟，而是以乌鸦的形式现身的某种古老的天空之灵。^o同一时间只能召唤一只乌鸦。乌鸦会受到战宠加成的影响。
 tagClass03SkillName01B=[神秘学者]风暴光球
 tagClass03SkillDescription01B=普通攻击。
 tagClass03SkillName01C=[神秘学者]血肉缝合
@@ -284,7 +284,7 @@ tagClass03SkillName01E=[神秘学者]闪电打击
 tagClass03SkillDescription01E=风暴乌鸦召唤强力的闪电来攻击附近的敌人。
 
 tagClass03SkillName02A=[神秘学者]召唤地狱犬
-tagClass03SkillDescription02A=从邪术国度召唤出一只地狱犬撕咬神秘学者的敌人。这种邪恶的野兽将跟随在你身旁战斗直至生命在火焰地狱里终结。^o同一时间只能召唤一只地狱犬。地狱犬会受到战宠加成影响。
+tagClass03SkillDescription02A=从邪术国度召唤出一只地狱犬撕咬神秘学者的敌人。这种邪恶的野兽将跟随在你身旁战斗直至生命在火焰地狱里终结。^o同一时间只能召唤一只地狱犬。地狱犬会受到战宠加成的影响。
 tagClass03SkillName02B=[神秘学者]灰烬之爪
 tagClass03SkillDescription02B=在地狱犬可触及的范围内使用硫磺之爪在敌人身上撕扯出一道道烈焰之弧。
 tagClass03SkillName02C=[神秘学者]地狱之火
@@ -426,7 +426,7 @@ tagClass04SkillName07B=[夜刃]夜之寒气
 tagClass04SkillDescription07B=使受到暗影面纱影响的敌人感到黑夜般的深寒降临，剥夺他们的生命并削弱防御。
 
 tagClass04SkillName08A=[夜刃]刀灵
-tagClass04SkillDescription08A=召唤一片旋涡云状的致命刀刃徘徊于战场，以锯齿状的碎片将敌人千刀万剐。^o刀灵会受到玩家的伤害加成影响。
+tagClass04SkillDescription08A=召唤一片旋涡云状的致命刀刃徘徊于战场，以锯齿状的碎片将敌人千刀万剐。^o刀灵会受到玩家伤害加成的影响。
 tagClass04SkillName08PetA=[夜刃]回旋刃
 tagClass04SkillName08PetB=[夜刃]刀刃爆发
 tagClass04SkillDescription08PetB=刀灵向四面八方发射开膛刀刃。
@@ -596,14 +596,14 @@ tagClass06SkillName02D=[萨满]雷电打击
 tagClass06SkillDescription02D=风暴召唤者，信奉上天的萨满教派的成员们，当向敌人释放自然的愤怒时，他们向天空之神 ~ 尤尔托斯呼唤，允许他们更加频繁的召唤雷电。^o雷电打击不是一项默认武器攻击，不能触发类似狂野饥渴的特效。
 
 tagClass06SkillName03A=[萨满]温迪戈图腾
-tagClass06SkillDescription03A=温迪戈图腾象征着萨满仪式中更黑暗的一面，崇尚自然的邪恶双重性：必须用一人的死亡来使另一个人得以喂食并存活。一旦被放置，图腾将会吸取附近敌人的生命，同时形成疗伤的光环治疗同伴。这种图腾被大部分部落设为禁忌。尽管如此，但原始的饥渴灵魂呼唤着它并使得很多萨满陷入了疯狂，让他们充满无厌的饥渴并因此不可避免的导致了自相残杀。^o温迪戈图腾受到人物伤害的加成。
+tagClass06SkillDescription03A=温迪戈图腾象征着萨满仪式中更黑暗的一面，崇尚自然的邪恶双重性：必须用一人的死亡来使另一个人得以喂食并存活。一旦被放置，图腾将会吸取附近敌人的生命，同时形成疗伤的光环治疗同伴。这种图腾被大部分部落设为禁忌。尽管如此，但原始的饥渴灵魂呼唤着它并使得很多萨满陷入了疯狂，让他们充满无厌的饥渴并因此不可避免的导致了自相残杀。^o温迪戈图腾会受到玩家伤害加成的影响。
 tagClass06SkillName03B=[萨满]血之契约
 tagClass06SkillDescription03B=与栖居在图腾中的温迪戈之灵签订契约，只要你位于光环范围内，你对血的渴望将变得无穷无尽。
 tagClass06SkillName03C=[萨满]生命源泉
 tagClass06SkillName03D=[萨满]治疗伤痛
 
 tagClass06SkillName04A=[萨满]风之恶魔
-tagClass06SkillDescription04A=在过去，萨满们经常在严重干旱时期呼唤降雨。这种仪式被一些聪明的风暴召唤者所掌控，并且召唤了一个漩涡般的风之恶魔，它会朝空中扔岩石以及残骸，重创敌人并用锋芒的元素之力蹂躏他们。^o风之恶魔会随着你的伤害而加强。
+tagClass06SkillDescription04A=在过去，萨满们经常在严重干旱时期呼唤降雨。这种仪式被一些聪明的风暴召唤者所掌控，并且召唤了一个漩涡般的风之恶魔，它会朝空中扔岩石以及残骸，重创敌人并用锋芒的元素之力蹂躏他们。^o风之恶魔会受到玩家伤害加成的影响。
 tagClass06SkillName04B=[萨满]狂风暴雨
 tagClass06SkillDescription04B=漩涡气流随着狂暴的力量增强。冰冻之风会使敌人麻木，并使得他们承受更多的元素伤害。
 tagClass06SkillName04C=[萨满]风暴漩涡
@@ -637,7 +637,7 @@ tagClass06SkillName08A=[萨满]风暴召唤者的契约
 tagClass06SkillDescription08A=与尤尔托斯 ~ 天空之神合为一体，将你的凡人躯体转变成为极具破坏力的闪电风暴的形态。^o这项技能必须保持开启以持续生效。
 
 tagClass06SkillName09A=[萨满]召唤原始之灵
-tagClass06SkillDescription09A=传说中有一名强大的掠食者，莫格卓根的衷心仆从，他无情地猎杀任何未受邀请而踏足野兽之神领地的人。作为莫格卓根的最喜爱的追随者，你可以召唤这个原始之灵来协助战斗。^o原始之灵会受到战宠加成影响。
+tagClass06SkillDescription09A=传说中有一名强大的掠食者，莫格卓根的衷心仆从，他无情地猎杀任何未受邀请而踏足野兽之神领地的人。作为莫格卓根的最喜爱的追随者，你可以召唤这个原始之灵来协助战斗。^o原始之灵会受到战宠加成的影响。
 tagClass06SkillName09B_Pet=[萨满]毒尾打击
 tagClass06SkillDescription09B_Pet=用带毒的尾巴攻击目标。
 tagClass06SkillName009C=[萨满]爪牙攻击
@@ -665,7 +665,7 @@ tagClass06SkillName15D=[萨满]吸血虫群
 tagClass06SkillDescription15D=虫群会造成伤害并转换成珍贵的生命之源给你。
 
 tagClass06SkillName16A=[萨满]风暴图腾
-tagClass06SkillDescription16A=与风暴之力沟通是风暴召唤者们的神圣仪式之一。通过足够的练习，萨满可以向一个温迪戈图腾注入闪电的破坏之力，使得它能快速的发出闪电攻击附近的敌人。^o风暴图腾受到人物的伤害加成影响。
+tagClass06SkillDescription16A=与风暴之力沟通是风暴召唤者们的神圣仪式之一。通过足够的练习，萨满可以向一个温迪戈图腾注入闪电的破坏之力，使得它能快速的发出闪电攻击附近的敌人。^o风暴图腾会受到玩家伤害加成的影响。
 tagClass06SkillName16B=[萨满]腐化风暴
 tagClass06SkillDescription16B=痴迷于温迪戈力量的扭曲萨满们可以腐化风暴图腾来释放使敌人活力衰竭的闪电。
 tagClass06SkillName16_Pet=[萨满]风暴打击
@@ -1089,7 +1089,7 @@ tagItemSkillC050Name=巫妖守卫
 tagItemSkillC050Desc=在危难之时，巫妖守卫会保护它的持有者免遭致命的伤害。
 
 tagItemSkillC051Name=召唤奥格·纳佩什的亡魂
-tagItemSkillC051Desc=施放奥格·纳佩什的黑魔法，将他那无比邪恶的亡魂召唤到尘世之中。^o同一时间只能召唤一只亡魂。亡魂会受到战宠加成影响。
+tagItemSkillC051Desc=施放奥格·纳佩什的黑魔法，将他那无比邪恶的亡魂召唤到尘世之中。^o同一时间只能召唤一只亡魂。亡魂会受到战宠加成的影响。
 tagItemSkillC051Pet01=盾牌守护
 tagItemSkillC051Pet01Desc=亡魂帮助周围的友军抵抗群体控制效果，并且强化他们的护甲与反击能力。
 
@@ -1193,7 +1193,7 @@ tagItemSkillC084Name=瘴气
 tagItemSkillC084Desc=释放一片毒气之云窒息并使敌人混乱。
 
 tagItemSkillC085Name=召唤枯萎者 ~ 裂隙之灾
-tagItemSkillC085Desc=从深渊中召唤裂隙之灾，它将听命于你。^o裂隙之灾会受到战宠加成影响。
+tagItemSkillC085Desc=从深渊中召唤裂隙之灾，它将听命于你。^o裂隙之灾会受到战宠加成的影响。
 tagItemSkillC085PetSkillName01=酸液喷吐
 tagItemSkillC085PetSkillName02=剧毒新星
 
@@ -1249,7 +1249,7 @@ tagItemSkillC102Name=火焰之爪
 tagItemSkillC102Desc=用地狱火爪将敌人一分为二。
 
 tagItemSkillC103Name=召唤贪食者
-tagItemSkillC103Desc=将一只冥煞贪食者从虚空中拉扯出来保护你。^o贪食者会受到战宠加成影响。
+tagItemSkillC103Desc=将一只冥煞贪食者从虚空中拉扯出来保护你。^o贪食者会受到战宠加成的影响。
 
 tagItemSkillC104Name=灵魂守卫
 tagItemSkillC104Desc=将身体的一部分进入到灵魂领域，提升你对生命吸取和物理攻击的抗性。
@@ -1392,7 +1392,7 @@ tagItemSkillD019Name=冰雹风暴
 tagItemSkillD019Desc=在目标区域召唤一阵致命的冰雹。
 
 tagItemSkillD020Name=召唤冥煞先锋
-tagItemSkillD020Desc=从虚空深处召唤出萨拉查的先锋。^o冥煞先锋会受到战宠加成影响。
+tagItemSkillD020Desc=从虚空深处召唤出萨拉查的先锋。^o冥煞先锋会受到战宠加成的影响。
 tagItemSkillD020PetSkillName=幽冥剧毒
 tagItemSkillD020PetSkillName02=混沌光环
 tagItemSkillD020PetSkillDesc02=萨拉查的先锋将混沌祝福给予它的盟友。
@@ -1494,15 +1494,15 @@ tagItemSkillD052Name=巨像之力
 tagItemSkillD052Desc=对于盾牌的精通掌握使你在战斗中化身为致命且无法阻挡的武器。^o这是一项盾牌被动技能。
 
 tagItemSkillD053Name=召唤黑暗之灾
-tagItemSkillD053Desc=你的肆意屠杀向虚空发出了呼唤。每当你亲手杀死一个敌人，就会召唤出一个饥肠辘辘的贪食者。^o黑暗之灾受战宠加成影响。
+tagItemSkillD053Desc=你的肆意屠杀向虚空发出了呼唤。每当你亲手杀死一个敌人，就会召唤出一个饥肠辘辘的贪食者。^o黑暗之灾会受到战宠加成的影响。
 tagItemSkillD053_Pet01=熵能终结
 
 tagItemSkillD054Name=守护者之眼
-tagItemSkillD054Desc=召唤德里格的无尽之眼中的一只来用尖刺屏障保护你。
+tagItemSkillD054Desc=召唤德里格的无尽之眼中的一只来用尖刺屏障保护你。^o守护者之眼会受到玩家伤害加成的影响
 tagItemSkillD054_Pet01=恶毒尖刺
 
 tagItemSkillD055Name=德里格的凝视
-tagItemSkillD055Desc=释放三只德里格的幽魂之眼来追踪你的敌人，爆裂出胆汁与毒液。^o德里格的凝视受到玩家伤害的加成影响。
+tagItemSkillD055Desc=释放三只德里格的幽魂之眼来追踪你的敌人，爆裂出胆汁与毒液。^o德里格的凝视会受到玩家伤害加成的影响。
 tagItemSkillD055_Pet01=腐蚀爆发
 
 tagItemSkillD056Name=末日战旗
@@ -1511,11 +1511,11 @@ tagItemSkillD056_Pet01=激励战旗
 tagItemSkillD056_Pet01Desc=在战旗附近战斗会激励你。
 
 tagItemSkillD057Name=混乱祈愿
-tagItemSkillD057Desc=向虚空呼唤并召唤虚空恶魔来为你战斗，直到它们返回虚空。^o恶魔会受到战宠加成影响。
+tagItemSkillD057Desc=向虚空呼唤并召唤虚空恶魔来为你战斗，直到它们返回虚空。^o恶魔会受到战宠加成的影响。
 tagItemSkillD057_Pet01=混乱烈焰
 
 tagItemSkillD058Name=幽灵复生
-tagItemSkillD058Desc=利用刚刚你亲手制造的杀戮能量来唤出一个痛苦的灵魂来协助你。^o灵魂会受到战宠加成影响。
+tagItemSkillD058Desc=利用刚刚你亲手制造的杀戮能量来唤出一个痛苦的灵魂来协助你。^o灵魂会受到战宠加成的影响。
 tagItemSkillD058_Pet01=幽灵触摸
 
 tagItemSkillD059Name=阿格维克斯的噬命
@@ -2020,7 +2020,7 @@ tagItemSkillD225Name=凛冬之王之力
 tagItemSkillD225Desc=利用凛冬之王之力将武器猛击大地，释放一波冰刺。^o需要一把双手近战武器。
 
 tagItemSkillD226Name=召唤寒鬃
-tagItemSkillD226Desc=召唤一只寒鬃雪人来为你战斗。^o同一时间只能召唤一只寒鬃。雪人受到战宠加成影响。
+tagItemSkillD226Desc=召唤一只寒鬃雪人来为你战斗。^o同一时间只能召唤一只寒鬃。雪人会受到战宠加成的影响。
 
 tagItemSkillD227Name=寒霜恐惧
 tagItemSkillD227Desc=释放寄居在你冰冻之心内的寒气，向你的武器中灌注能够吸取生命力的恶寒。此效果会延伸到附近盟友身上。^o这项技能必须保持开启以持续生效。
@@ -2076,13 +2076,13 @@ tagItemSkillD243NamePetSkill=增强仪式
 tagItemSkillD243DescPetSkill=身处仪式之环中会增强你的法术并且保护你免受物理伤害。
 
 tagItemSkillD244Name=风暴裂片
-tagItemSkillD244Desc=在目标地点召唤一枚充满风暴之力的水晶来震击附近的敌人。^o风暴裂片随着玩家的伤害而增强。
+tagItemSkillD244Desc=在目标地点召唤一枚充满风暴之力的水晶来震击附近的敌人。^o风暴裂片会受到玩家伤害加成的影响。
 
 tagItemSkillD245Name=地狱火
 tagItemSkillD245Desc=从敌人脚下召唤出地狱烈焰。
 
 tagItemSkillD246Name=阿格维克斯的契约
-tagItemSkillD246Desc=向敌人释放一只充满奥术能量的精灵。^o奥术精灵会随着玩家伤害增强。
+tagItemSkillD246Desc=向敌人释放一只充满奥术能量的精灵。^o奥术精灵会受到玩家伤害加成的影响。
 tagItemSkillD246NamePetSkill=奥术震荡
 
 tagItemSkillD247Name=战争之子
@@ -2337,7 +2337,7 @@ tagRelicSkillC008Name=爆炎
 tagRelicSkillC008Desc=发动一束强烈到即使最坚固的护甲也无法抵挡的穿透性纯净火焰。^o这是一项引导技能，需要持续施法。施法速度为100%时，爆炎每0.3s造成伤害并消耗能量。
 
 tagRelicSkillC009Name=召唤风暴魔犬
-tagRelicSkillC009Desc=召唤一只忠诚的风暴魔犬 ~ 源于天堂的可怕野兽。^o同一时间只能召唤一只风暴魔犬。风暴魔犬会受到战宠加成影响。
+tagRelicSkillC009Desc=召唤一只忠诚的风暴魔犬 ~ 源于天堂的可怕野兽。^o同一时间只能召唤一只风暴魔犬。风暴魔犬会受到战宠加成的影响。
 
 tagRelicSkillC010Name=死寒光环
 tagRelicSkillC010Desc=以恐怖阴森的死亡之寒强化你和你附近队友的攻击。^o此技能需要开启以保持生效。
@@ -2365,7 +2365,7 @@ tagRelicSkillD002Name=诅咒
 tagRelicSkillD002Desc=用腐蚀毒药和致命疾病灌注你的武器，每一击都能感染你的敌人。^o这项技能必须保持开启以持续生效。
 
 tagRelicSkillD003Name=召唤复仇女神
-tagRelicSkillD003Desc=召唤复仇女神 ~ 暗影半神以及暗夜狩猎之王。^o你在同一时间只能召唤一个复仇女神的化身。复仇女神受到玩家伤害影响。
+tagRelicSkillD003Desc=召唤复仇女神 ~ 暗影半神以及暗夜狩猎之王。^o你在同一时间只能召唤一个复仇女神的化身。复仇女神会受到玩家伤害加成的影响。
 
 tagRelicSkillD004Name=堡垒
 tagRelicSkillD004Desc=增强你和队友的防御，使你们成为移动的堡垒。^o这项技能必须保持开启以持续生效。
@@ -2767,12 +2767,12 @@ tagDevotionEffectB09Desc=在地上标记一个朝敌人喷射的奥术魔印。^
 tagDevotionEffectB09_Pet01=奥术标记
 tagDevotionEffectB09_Pet01Desc=用一枚奥术炸弹标记目标。
 tagDevotionEffectB10=亡者复生
-tagDevotionEffectB10Desc=复生一名亡者来为你作战。这项仪式所需要的腐坏能量是很不稳定的，这些亡灵仆从只能在有限的一段时间内存在。^o亡者会受到玩家伤害加成影响。
+tagDevotionEffectB10Desc=复生一名亡者来为你作战。这项仪式所需要的腐坏能量是很不稳定的，这些亡灵仆从只能在有限的一段时间内存在。^o亡者会受到玩家伤害加成的影响。
 tagDevotionEffectB10_Pet01=近战攻击
 tagDevotionEffectB11=畏惧之焰
 tagDevotionEffectB11Desc=畏惧烈焰从你的撞击中爆发并在敌人之间弹跳。
 tagDevotionEffectB12=拜斯迈的命令
-tagDevotionEffectB12Desc=召唤一只可怕的猎犬来猛咬并撕裂敌人。猎犬在现实世界的存在是很不稳定的，它只会在有限的时间内存在。^o猎犬会受到战宠加成影响。
+tagDevotionEffectB12Desc=召唤一只可怕的猎犬来猛咬并撕裂敌人。猎犬在现实世界的存在是很不稳定的，它只会在有限的时间内存在。^o猎犬会受到战宠加成的影响。
 tagDevotionEffectB12_Pet01=撕咬
 tagDevotionEffectB12_Pet02=瘟疫吐息
 tagDevotionEffectB13=狂野风暴
@@ -2821,13 +2821,13 @@ tagDevotionEffectC10Desc=一阵抚慰的薄雾从你身上散发而出，愈合�
 tagDevotionEffectC11=莫格卓根的嚎叫
 tagDevotionEffectC11Desc=受到鲜血杀戮的刺激，使你和你的仆从进入暴怒状态。
 tagDevotionEffectC12=元素探寻者
-tagDevotionEffectC12Desc=召唤一个可怕的纯净能量生物，在它归于奥术能量爆炸之前搜寻并燃烧附近的敌人。^o元素探寻者受到玩家伤害影响。
+tagDevotionEffectC12Desc=召唤一个可怕的纯净能量生物，在它归于奥术能量爆炸之前搜寻并燃烧附近的敌人。^o元素探寻者会受到玩家伤害加成的影响。
 tagDevotionEffectC12_Pet01=点燃
 tagDevotionEffectC12_Pet02=爆炸
 tagDevotionEffectC13=激流漩涡
 tagDevotionEffectC13Desc=激流的深渊如饥渴的漩涡一般向敌人释放来毁灭他们。
 tagDevotionEffectC14=暗影复生
-tagDevotionEffectC14Desc=将一名无名英雄复生来与你并肩作战。每次暗影攻击都会回复你的生命值。^o暗影复生受到玩家伤害影响。
+tagDevotionEffectC14Desc=将一名无名英雄复生来与你并肩作战。每次暗影攻击都会回复你的生命值。^o暗影复生会受到玩家伤害加成的影响。
 tagDevotionEffectC14_Pet01=暗影突袭
 tagDevotionEffectC14_Pet02=暗影刀锋
 


### PR DESCRIPTION
**1. 统一了以下两种翻译：**

- 将"scale(s) with pet bonuses"翻译为“会受到战宠加成的影响”
- 将"scale(s) with player damage bonuser"翻译为“会受到玩家伤害加成的影响”

**2. 将圣物描述的"Completion Bonus"的翻译从”完整部件奖励“改为”完成奖励“**

**3. 修改了一些其他技能说明的翻译错误**